### PR TITLE
Create active font list that excludes deprecated fonts

### DIFF
--- a/lib/bigcartel/theme/fonts/theme_font.rb
+++ b/lib/bigcartel/theme/fonts/theme_font.rb
@@ -1,6 +1,8 @@
 require 'yaml'
 
 class ThemeFont < Struct.new(:name, :family, :weights, :collection)
+  DEPRECATED_FONTS = ["Cutive"]
+
   class << self
     def all
       @@all ||= Array.new.tap { |fonts|
@@ -10,6 +12,12 @@ class ThemeFont < Struct.new(:name, :family, :weights, :collection)
           }
         }
       }.sort_by { |font| font.name }
+    end
+
+    def all_active
+      @@all_active ||= all.reject do |font|
+        deprecated?(font.name)
+      end
     end
 
     def options
@@ -28,6 +36,10 @@ class ThemeFont < Struct.new(:name, :family, :weights, :collection)
       else
         name
       end
+    end
+
+    def deprecated?(name)
+      DEPRECATED_FONTS.include?(name)
     end
 
     def google_fonts

--- a/spec/theme_font_spec.rb
+++ b/spec/theme_font_spec.rb
@@ -18,6 +18,16 @@ describe ThemeFont do
       ThemeFont.all.first.name.should == 'Abril Fatface'
       ThemeFont.all.last.name.should == 'Work Sans'
     end
+
+    it "should include deprecated fonts" do
+      ThemeFont.all.any? { |font| font.name == "Cutive" }.should == true
+    end
+  end
+
+  describe ".all_active" do
+    it "should not return deprecated theme fonts" do
+      ThemeFont.all_active.any? { |font| font.name == "Cutive" }.should == false
+    end
   end
 
   describe ".options" do
@@ -54,6 +64,20 @@ describe ThemeFont do
 
     it "should return the font name if no font is found" do
       ThemeFont.find_family_by_name('Blah').should == 'Blah'
+    end
+  end
+
+  describe ".deprecated?" do
+    it "returns true if font is deprecated" do
+      ThemeFont.deprecated?("Cutive").should == true
+    end
+
+    it "returns false if font is not deprecated" do
+      ThemeFont.deprecated?("Times New Roman").should == false
+    end
+
+    it "returns false if font is garbage" do
+      ThemeFont.deprecated?("You're Killing Me Buster").should == false
     end
   end
 


### PR DESCRIPTION
Adds concept of a deprecated font to the gem, and provides methods for a list of all active (i.e. undeprecated) fonts and a boolean check to see if a font is deprecated. 