### PR TITLE
v1.8.0

### DIFF
--- a/bigcartel-theme-fonts.gemspec
+++ b/bigcartel-theme-fonts.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'bigcartel-theme-fonts'
-  spec.version       = '1.7.0'
+  spec.version       = '1.8.0'
   spec.authors       = ['Big Cartel']
   spec.email         = ['dev@bigcartel.com']
   spec.description   = %q{A simple class for working with Big Cartel's supported theme fonts.}

--- a/lib/bigcartel/theme/fonts/theme_font.rb
+++ b/lib/bigcartel/theme/fonts/theme_font.rb
@@ -66,6 +66,33 @@ class ThemeFont < Struct.new(:name, :family, :weights, :collection)
       google_fonts.empty? ? nil : google_font_url_for_fonts(google_fonts)
     end
 
+    def google_font_url_for_theme_array(fonts, settings, options = {})
+      defaults = {
+        include_protocol: false,
+        include_weights: true
+      }
+      opts = defaults.merge(options)
+
+      google_fonts = fonts.keys.map { |key| settings[key] }.compact
+        .map { |font_name| find_by_name(font_name) }
+        .compact
+        .select { |font| font.collection == 'google' }
+        .sort_by { |font| font.name }
+
+      return [] if google_fonts.empty?
+
+      base_url = opts[:include_protocol] ? "https://fonts.googleapis.com/css?family=" : "//fonts.googleapis.com/css?family="
+
+      google_fonts.map do |font|
+        font_string = if opts[:include_weights] && font.weights
+                        "#{font.name}:#{font.weights}"
+                      else
+                        font.name
+                      end
+        "#{base_url}#{font_string.gsub(' ', '+')}&display=swap"
+      end
+    end
+
     private
 
     def source

--- a/lib/bigcartel/theme/fonts/theme_fonts.yml
+++ b/lib/bigcartel/theme/fonts/theme_fonts.yml
@@ -57,6 +57,10 @@ google:
     name: Abril Fatface
     family: '"Abril Fatface", cursive'
 
+  alumni_sans_pinstripe:
+    name: Alumni Sans Pinstripe
+    family: '"Alumni Sans Pinstripe", sans-serif'
+
   amaranth:
     name: Amaranth
     family: '"Amaranth", serif'
@@ -75,6 +79,15 @@ google:
   asap:
     name: Asap
     family: '"Asap", sans-serif'
+
+  atkinson_hyperlegible_next:
+    name: Atkinson Hyperlegible Next
+    family: '"Atkinson Hyperlegible Next", sans-serif'
+    weights: "200,300,400,500,600,700,800"
+
+  atma:
+    name: Atma
+    family: 'Atma, sans-serif'
 
   bevan:
     name: Bevan
@@ -103,6 +116,10 @@ google:
     family: '"Chivo", sans-serif'
     weights: "400,700"
 
+  coiny:
+    name: Coiny
+    family: '"Coiny", cursive'
+
   concert_one:
     name: Concert One
     family: '"Concert One", cursive'
@@ -119,6 +136,10 @@ google:
   cutive_mono:
     name: Cutive Mono
     family: '"Cutive Mono", serif'
+
+  dekko:
+    name: Dekko
+    family: 'Dekko, sans-serif'
 
   delius:
     name: Delius
@@ -172,6 +193,11 @@ google:
     family: '"Glegoo", serif'
     weights: "400,700"
 
+  gorditas:
+    name: Gorditas
+    family: '"Gorditas", sans-serif'
+    weights: "400,700"
+
   goudy_bookletter_1911:
     name: Goudy Bookletter 1911
     family: '"Goudy Bookletter 1911", serif'
@@ -180,6 +206,10 @@ google:
     name: Hahmlet
     family: '"Hahmlet", serif'
     weights: "400,700"
+
+  honk:
+    name: Honk
+    family: 'Honk, sans-serif'
 
   inconsolata:
     name: Inconsolata
@@ -200,6 +230,10 @@ google:
     name: Karla
     family: '"Karla", sans-serif'
     weights: "300,400,500,700"
+
+  langar:
+    name: Langar
+    family: '"Langar", cursive'
 
   lato:
     name: Lato
@@ -299,6 +333,10 @@ google:
     family: '"ParkinSans", sans-serif'
     weights: "300,400,500,700"
 
+  permanent_marker:
+    name: Permanent Marker
+    family: '"Permanent Marker", cursive'
+
   playfair_display:
     name: Playfair Display
     family: '"Playfair Display", serif'
@@ -351,6 +389,16 @@ google:
     name: Raleway
     family: '"Raleway", sans-serif'
     weights: "400,700"
+
+  radio_canada:
+    name: Radio Canada
+    family: '"Radio Canada", sans-serif'
+    weights: "300,400,500,600,700"
+
+  reddit_sans:
+    name: Reddit Sans
+    family: '"Reddit Sans", sans-serif'
+    weights: "200,300,400,500,600,700,800"
 
   roboto:
     name: Roboto

--- a/spec/theme_font_spec.rb
+++ b/spec/theme_font_spec.rb
@@ -143,4 +143,83 @@ describe ThemeFont do
       ThemeFont.google_font_url_for_theme(fonts, settings).should be_nil
     end
   end
+
+  describe ".google_font_url_for_theme_array" do
+    let(:fonts) {{ :header_font => {}, :body_font => {}, :paragraph_font => {} }}
+
+    before(:each) do
+      stub(ThemeFont).all {[
+        ThemeFont.new('One Font', 'One Family', '400,700', 'google'),
+        ThemeFont.new('Two', 'Two Family', nil, 'default'),
+        ThemeFont.new('Three', 'Three Family', '300,600', 'google')
+      ]}
+    end
+
+    context "with default options" do
+      it "returns an array of URLs with weights and no protocol" do
+        settings = { :header_font => 'One Font', :body_font => 'Two', :paragraph_font => 'Three' }
+        result = ThemeFont.google_font_url_for_theme_array(fonts, settings)
+        result.should == [
+          "//fonts.googleapis.com/css?family=One+Font:400,700&display=swap",
+          "//fonts.googleapis.com/css?family=Three:300,600&display=swap"
+        ]
+      end
+
+      it "returns a single URL in array when only one Google font" do
+        settings = { :header_font => 'One Font', :body_font => 'Two' }
+        result = ThemeFont.google_font_url_for_theme_array(fonts, settings)
+        result.should == ["//fonts.googleapis.com/css?family=One+Font:400,700&display=swap"]
+      end
+
+      it "returns empty array when no Google fonts" do
+        settings = { :body_font => 'Two' }
+        result = ThemeFont.google_font_url_for_theme_array(fonts, settings)
+        result.should == []
+      end
+
+      it "deduplicates identical fonts" do
+        settings = { :header_font => 'One Font', :body_font => 'One Font' }
+        result = ThemeFont.google_font_url_for_theme_array(fonts, settings)
+        result.should == ["//fonts.googleapis.com/css?family=One+Font:400,700&display=swap"]
+      end
+    end
+
+    context "with include_protocol: true" do
+      it "returns URLs with https protocol" do
+        settings = { :header_font => 'One Font', :paragraph_font => 'Three' }
+        result = ThemeFont.google_font_url_for_theme_array(fonts, settings, include_protocol: true)
+        result.should == [
+          "https://fonts.googleapis.com/css?family=One+Font:400,700&display=swap",
+          "https://fonts.googleapis.com/css?family=Three:300,600&display=swap"
+        ]
+      end
+    end
+
+    context "with include_weights: false" do
+      it "returns URLs without weights" do
+        settings = { :header_font => 'One Font', :paragraph_font => 'Three' }
+        result = ThemeFont.google_font_url_for_theme_array(fonts, settings, include_weights: false)
+        result.should == [
+          "//fonts.googleapis.com/css?family=One+Font&display=swap",
+          "//fonts.googleapis.com/css?family=Three&display=swap"
+        ]
+      end
+    end
+
+    context "with both options customized" do
+      it "returns URLs with protocol and no weights" do
+        settings = { :header_font => 'One Font', :paragraph_font => 'Three' }
+        result = ThemeFont.google_font_url_for_theme_array(
+          fonts,
+          settings,
+          include_protocol: true,
+          include_weights: false
+        )
+        result.should == [
+          "https://fonts.googleapis.com/css?family=One+Font&display=swap",
+          "https://fonts.googleapis.com/css?family=Three&display=swap"
+        ]
+      end
+    end
+  end
 end


### PR DESCRIPTION
Introduces `google_font_url_for_theme_array` method to generate Google Fonts URLs based on an array of theme fonts. Includes tests for various options such as protocol inclusion and weight handling. Updates gem version to 1.8.0.

This will be useful for storefront to be able to get the URLs directly for google fonts.

Also adds new 8 new fonts