### PR TITLE
fix: nil theme name error in font URL generation

### DIFF
--- a/bigcartel-theme-fonts.gemspec
+++ b/bigcartel-theme-fonts.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = 'bigcartel-theme-fonts'
-  spec.version       = '1.8.4'
+  spec.version       = '1.8.5'
   spec.authors       = ['Big Cartel']
   spec.email         = ['dev@bigcartel.com']
   spec.description   = %q{A simple class for working with Big Cartel's supported theme fonts.}

--- a/lib/bigcartel/theme/fonts/theme_font.rb
+++ b/lib/bigcartel/theme/fonts/theme_font.rb
@@ -67,6 +67,8 @@ class ThemeFont < Struct.new(:name, :family, :weights, :collection)
     end
 
     def google_font_url_for_theme_json(account_theme)
+      return {} if account_theme.theme&.name.nil?
+
       # Cosmos and Lunch Break use the secondary font for the primary text font
       font_setting = if ["cosmos", "lunch break"].include?(account_theme.theme.name.downcase)
         account_theme.settings[:secondary_font]


### PR DESCRIPTION
Adds a check to return an empty hash if the account theme name is nil before generating the Google font URL, preventing potential errors.

Bumps gem version to 1.8.5.